### PR TITLE
添加了新的方法，只在激怒可用时变熊

### DIFF
--- a/Libs/Options.lua
+++ b/Libs/Options.lua
@@ -23,6 +23,8 @@ local function WhitePaws_Command(arg)
 		pcall(wcEnd)
 	elseif arg1 == 'bxjgx' then
 		pcall(bxjgx, tonumber(arg2))
+	elseif arg1 == 'jnbxjgx' then
+		pcall(jnbxjgx, tonumber(arg2))
 	elseif arg1 == 'bxjgm' then
 		pcall(bxjgm, tonumber(arg2))
 	else

--- a/Libs/wcCore.lua
+++ b/Libs/wcCore.lua
@@ -125,6 +125,23 @@ function wc.getBuff(...)
 	return false
 end
 
+--狂暴50334 激怒5229 猛虎9846 50212 50213
+function wc.getBuffTime(...)
+	local buffs = {}, i, v
+	for i, v in ipairs{...} do
+		buffs[v] = true;
+	end
+	i = 1
+	while UnitBuff('player', i) do
+		if buffs[select(1, UnitBuff('player', i))] or buffs[select(10, UnitBuff('player', i))] then
+			local _, _, _, _, _, duration, expirationTime = UnitBuff("player", i)
+     		return expirationTime - GetTime()
+		end
+		i = i + 1
+	end
+	return 0
+end
+
 function wc.getDebuff(...)
 	local debuffs = {}, i, v
 	for i, v in ipairs{...} do
@@ -163,4 +180,8 @@ function wc.needUnroot()
 	elseif select(2, GetUnitSpeed('player')) < 7 and not IsStealthed() then return true
 	else return false end
 	--todo dazed 眩晕 震荡射击
+end
+
+function wc.getComboPoint()
+	return GetComboPoints('player','target')
 end

--- a/Libs/wcCore.lua
+++ b/Libs/wcCore.lua
@@ -164,7 +164,7 @@ function wc.enoughMana(cost)
 	return UnitPower('player', 0) >= cost
 end
 
--- 清洗预兆 16870
+-- 清晰预兆 16870
 -- 猛虎 50213
 
 function wc.enoughEnergy(cost)

--- a/Libs/wcCore.lua
+++ b/Libs/wcCore.lua
@@ -164,8 +164,11 @@ function wc.enoughMana(cost)
 	return UnitPower('player', 0) >= cost
 end
 
+-- 清洗预兆 16870
+-- 猛虎 50213
+
 function wc.enoughEnergy(cost)
-	if wc.getBuff(16870) then
+	if wc.getBuff(16870) or GetSpellCooldown(50213) == 0 then
 		return true
 	end
 	return wc.getEnergy() >= cost

--- a/Libs/wcCore.lua
+++ b/Libs/wcCore.lua
@@ -134,7 +134,7 @@ function wc.getBuffTime(...)
 	i = 1
 	while UnitBuff('player', i) do
 		if buffs[select(1, UnitBuff('player', i))] or buffs[select(10, UnitBuff('player', i))] then
-			local _, _, _, _, _, duration, expirationTime = UnitBuff("player", i)
+			local _, _, _, _, duration, expirationTime = UnitBuff("player", i)
      		return expirationTime - GetTime()
 		end
 		i = i + 1
@@ -168,7 +168,7 @@ end
 -- 猛虎 50213
 
 function wc.enoughEnergy(cost)
-	if wc.getBuff(16870) or GetSpellCooldown(50213) == 0 then
+	if wc.getBuff(16870) or GetSpellCooldown(50213) < 2 then
 		return true
 	end
 	return wc.getEnergy() >= cost

--- a/Libs/wcCore.lua
+++ b/Libs/wcCore.lua
@@ -168,7 +168,7 @@ end
 -- 猛虎 50213
 
 function wc.enoughEnergy(cost)
-	if wc.getBuff(16870) or GetSpellCooldown(50213) < 2 then
+	if wc.getBuff(16870) or wc.getCoolDown(50213) < 2 then
 		return true
 	end
 	return wc.getEnergy() >= cost
@@ -187,4 +187,12 @@ end
 
 function wc.getComboPoint()
 	return GetComboPoints('player','target')
+end
+
+function wc.getCoolDown(spellID)
+	local cooldown, duration = GetSpellCooldown(spellID)
+	if cooldown == 0 then
+		return cooldown
+	end
+	return cooldown + duration - GetTime()
 end

--- a/Libs/wcCore.lua
+++ b/Libs/wcCore.lua
@@ -168,7 +168,7 @@ end
 -- 猛虎 50213
 
 function wc.enoughEnergy(cost)
-	if wc.getBuff(16870) or wc.getCoolDown(50213) < 2 then
+	if (wc.getBuff(16870) and wc.getRage() < 25) or wc.getCoolDown(50213) < 2 then
 		return true
 	end
 	return wc.getEnergy() >= cost

--- a/WhitePaws.lua
+++ b/WhitePaws.lua
@@ -57,7 +57,7 @@ end
 
 --变形金刚-变猫
 function bxjgm(e)
-	if not wc.strongControl and wc.enoughMana() and (wc.needUnroot() or (wc.enoughEnergy(e) and wc.getRage() < 25)) then
+	if not wc.strongControl and wc.enoughMana() and (wc.needUnroot() or wc.enoughEnergy(e)) then
 		if not wc.getShiftGCD() then
 			SetCVar('autoUnshift', 1)
 		else

--- a/WhitePaws.lua
+++ b/WhitePaws.lua
@@ -35,7 +35,7 @@ end
 
 --变形金刚-变熊
 function bxjgx(e)
-	if not wc.strongControl and wc.enoughMana() and not wc.getShiftGCD() and not wc.enoughEnergy(e) and not wc.getBuff(50334) and GetSpellCooldown(50213) ~= 0 then
+	if not wc.strongControl and wc.enoughMana() and not wc.getShiftGCD() and not wc.enoughEnergy(e) and not wc.getBuff(50334) and wc.getBuffTime(52610) > 5 and GetSpellCooldown(50213) ~= 0 and wc.getComboPoint() < 4 then
 		SetCVar('autoUnshift', 1)
 	else
 		SetCVar('autoUnshift', 0)
@@ -43,6 +43,7 @@ function bxjgx(e)
 end
 
 --变形金刚-激怒变熊
+-- 52610 野蛮咆哮
 -- 50213 猛虎之怒
 -- 5229 激怒
 function jnbxjgx(e)
@@ -55,7 +56,7 @@ end
 
 --变形金刚-变猫
 function bxjgm(e)
-	if not wc.strongControl and wc.enoughMana() and (wc.needUnroot() or (wc.enoughEnergy(e) and not wc.getBuff(50334))) then
+	if not wc.strongControl and wc.enoughMana() and (wc.needUnroot() or (wc.enoughEnergy(e) and wc.getRage() < 20) or GetSpellCooldown(50213) == 0) then
 		if not wc.getShiftGCD() then
 			SetCVar('autoUnshift', 1)
 		else

--- a/WhitePaws.lua
+++ b/WhitePaws.lua
@@ -57,7 +57,7 @@ end
 
 --变形金刚-变猫
 function bxjgm(e)
-	if not wc.strongControl and wc.enoughMana() and (wc.needUnroot() or (wc.enoughEnergy(e) and wc.getRage() < 20)) then
+	if not wc.strongControl and wc.enoughMana() and (wc.needUnroot() or (wc.enoughEnergy(e) and wc.getRage() < 25)) then
 		if not wc.getShiftGCD() then
 			SetCVar('autoUnshift', 1)
 		else

--- a/WhitePaws.lua
+++ b/WhitePaws.lua
@@ -35,7 +35,7 @@ end
 
 --变形金刚-变熊
 function bxjgx(e)
-	if not wc.strongControl and wc.enoughMana() and not wc.getShiftGCD() and not wc.enoughEnergy(e) and not wc.getBuff(50334) and wc.getBuffTime(52610) > 5 and GetSpellCooldown(50213) ~= 0 and wc.getComboPoint() < 4 then
+	if not wc.strongControl and wc.enoughMana() and not wc.getShiftGCD() and not wc.enoughEnergy(e) and not wc.getBuff(50334) and wc.getBuffTime(52610) > 5 and wc.getComboPoint() < 4 then
 		SetCVar('autoUnshift', 1)
 	else
 		SetCVar('autoUnshift', 0)
@@ -46,8 +46,9 @@ end
 -- 52610 野蛮咆哮
 -- 50213 猛虎之怒
 -- 5229 激怒
+-- 50334 狂暴
 function jnbxjgx(e)
-	if not wc.strongControl and wc.enoughMana() and not wc.getShiftGCD() and not wc.enoughEnergy(e) and not wc.getBuff(50334) and GetSpellCooldown(50213) ~= 0 and GetSpellCooldown(5229) == 0 then
+	if not wc.strongControl and wc.enoughMana() and not wc.getShiftGCD() and not wc.enoughEnergy(e) and not wc.getBuff(50334) and GetSpellCooldown(5229) == 0 then
 		SetCVar('autoUnshift', 1)
 	else
 		SetCVar('autoUnshift', 0)
@@ -56,7 +57,7 @@ end
 
 --变形金刚-变猫
 function bxjgm(e)
-	if not wc.strongControl and wc.enoughMana() and (wc.needUnroot() or (wc.enoughEnergy(e) and wc.getRage() < 20) or GetSpellCooldown(50213) == 0) then
+	if not wc.strongControl and wc.enoughMana() and (wc.needUnroot() or (wc.enoughEnergy(e) and wc.getRage() < 20)) then
 		if not wc.getShiftGCD() then
 			SetCVar('autoUnshift', 1)
 		else

--- a/WhitePaws.lua
+++ b/WhitePaws.lua
@@ -42,6 +42,17 @@ function bxjgx(e)
 	end
 end
 
+--变形金刚-激怒变熊
+-- 50213 猛虎之怒
+-- 5229 激怒
+function jnbxjgx(e)
+	if not wc.strongControl and wc.enoughMana() and not wc.getShiftGCD() and not wc.enoughEnergy(e) and not wc.getBuff(50334) and GetSpellCooldown(50213) ~= 0 and GetSpellCooldown(5229) == 0 then
+		SetCVar('autoUnshift', 1)
+	else
+		SetCVar('autoUnshift', 0)
+	end
+end
+
 --变形金刚-变猫
 function bxjgm(e)
 	if not wc.strongControl and wc.enoughMana() and (wc.needUnroot() or (wc.enoughEnergy(e) and not wc.getBuff(50334))) then

--- a/WhitePaws.toc
+++ b/WhitePaws.toc
@@ -1,7 +1,7 @@
 ## Interface: 30400
 ## Title: 白爪助手@project-version@
 ## Version: @project-version@
-## Author: NGA:alawing (失眠者白爪-辛迪加) NGA:cksky
+## Author: NGA:alawing (失眠者白爪-辛迪加) NGA:cksky NGA:weryis
 ## Notes: 白爪助手辅助插件
 ## SavedVariablesPerCharacter: originTrinket
 ## SavedVariablesPerCharacter: cancelQueue

--- a/devlog.txt
+++ b/devlog.txt
@@ -40,3 +40,15 @@ C_LossOfControl.GetActiveLossOfControlDataByUnit
 					ChatFrame3:AddMessage('----------------------')
 
 /dump GetItemStats('达图尔的变形魔棒')
+
+/run print(select(6, UnitBuff("player", 2))[0])
+
+/run print(UnitBuff("player", 2))
+
+/run print(GetSpellCooldown(50213))
+
+/run SELECTED_CHAT_FRAME:AddMessage(GetTime())
+
+/run local _, _, _, _, duration, expirationTime = UnitBuff("player", 6);SELECTED_CHAT_FRAME:AddMessage(expirationTime - GetTime())
+
+/run local cooldown,duration = GetSpellCooldown(50213);print(cooldown + duration - GetTime())


### PR DESCRIPTION
1. 团本中满buff状态下猫形态普攻收益更高，且熊猫转换时有概率卡普攻导致变熊后怒气不足
2. 目前的方法，如果熊形态第一次普攻触发了清晰预兆，会马上切换回猫形态，相当于浪费了两个公共CD

添加了新的方法：

jnbxjgx （激怒变形金刚熊）

判断：

GetSpellCooldown(5229) == 0

激怒技能可用时才变熊，降低变身频率，解决卡怒气问题。

